### PR TITLE
Non iupac filter

### DIFF
--- a/bin/elan_fastacheck.py
+++ b/bin/elan_fastacheck.py
@@ -32,6 +32,8 @@ def readfq(fp): # this is a generator function
             if last: # reach EOF before reading enough quality
                 yield name, seq, None # yield a fasta record instead
                 break
+                
+IUPAC_chars = ["A","C","G","T","U","R","Y","K","M","S","W","B","D","H","V","N","-"]
 
 if len(sys.argv) != 3:
     sys.exit(1)
@@ -50,6 +52,8 @@ if not name:
     sys.exit(1)
 if not seq:
     sys.exit(2)
+if any(base not in IUPAC_chars for base in seq):
+    sys.exit(65)
 if len(seq) < min_len:
     sys.exit(3)
 fasta_fh.close()

--- a/bin/elan_fastacheck.py
+++ b/bin/elan_fastacheck.py
@@ -33,7 +33,7 @@ def readfq(fp): # this is a generator function
                 yield name, seq, None # yield a fasta record instead
                 break
                 
-IUPAC_chars = ["A","C","G","T","U","R","Y","K","M","S","W","B","D","H","V","N","-"]
+iupac_chars = set("ACGTRYKMSWBDHVN")
 
 if len(sys.argv) != 3:
     sys.exit(1)
@@ -52,7 +52,7 @@ if not name:
     sys.exit(1)
 if not seq:
     sys.exit(2)
-if any(base not in IUPAC_chars for base in seq):
+if any(upper(base) not in iupac_chars for base in seq):
     sys.exit(65)
 if len(seq) < min_len:
     sys.exit(3)

--- a/bin/elan_fastacheck.py
+++ b/bin/elan_fastacheck.py
@@ -52,7 +52,7 @@ if not name:
     sys.exit(1)
 if not seq:
     sys.exit(2)
-if any(upper(base) not in iupac_chars for base in seq):
+if any(base.upper() not in iupac_chars for base in seq):
     sys.exit(65)
 if len(seq) < min_len:
     sys.exit(3)


### PR DESCRIPTION
Added logic to automatically kick out fasta files which contain non-IUPAC characters to avoid situtations such as [these](https://github.com/COG-UK/dipi-group/issues/178) and generally remove one potential source of data badness.