### PR TITLE
Second universal newline patch

### DIFF
--- a/elan.nf
+++ b/elan.nf
@@ -105,6 +105,7 @@ process samtools_quickcheck {
 process fasta_quickcheck {
     tag { fasta }
     label 'bear'
+    conda "environments/ocarina.yaml"
 
     validExitStatus 0,1,2,3,4,5,6,7,8
 


### PR DESCRIPTION
Made fasta_quickcheck actually run in an env so it doesn't just default to base (py2), it didn't seem worth making a new one for this.